### PR TITLE
feat: add an entrypoint script to simplify docker args

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ nohup.out
 
 
 start.sh
+.token
+.cookies
+credentials/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,14 @@ RUN apk add --no-cache git
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && rm -rf /root/.cache
-COPY tg.py .
+COPY *.py .
 
-ENV tg_token=$tg_token
-ENV bing_cookie=$bing_cookie
+# Entrypoint script
+COPY entrypoint.sh .
+RUN chmod +x /app/entrypoint.sh
 
-CMD python3 tg.py $tg_token $bing_cookie
+# Default env vars
+ENV tg_token=${tg_token:-}
+ENV bing_cookie=${bing_cookie:-}
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -58,9 +58,15 @@ Or you can use docker to run it:
 1. `docker build -t tg_bing_dalle .`
 2. `docker run -d --name tg_bing_dalle -e tg_token='${tg_token}' -e bing_cookie='${bing_cookie}' --network host tg_bing_dalle`
 
+If you want to use multiple cookies, you could save to `credentials/.cookies` with one cookie per line. Then use this command to run it:
+
+`docker run -d --name tg_bing_dalle -e tg_token='${tg_token}' --network host --volume ./credentials/:/credentials tg_bing_dalle`
+
+You could also save your tg token to `credentials/.token` to instead of passing it via environment variables.
+
 ## Contribution
 
-- Any issues PR welcome.
+- Any issue reports or PRs are welcome.
 - Any other bot type like slack/discord welcome
 - Before PR, use `pip install -U black` then `black .` first
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Load args from files if exist, otherwise env vars
 if [ -f "/credentials/.token" ]; then
-	tg_token=$(cat /credentials/.token)
+  tg_token=$(cat /credentials/.token)
 fi
 
 if [ -f "/credentials/.cookies" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Load args from files if exist, otherwise env vars
+if [ -f "/credentials/.token" ]; then
+	tg_token=$(cat /credentials/.token)
+fi
+
+if [ -f "/credentials/.cookies" ]; then
+  bing_cookies=""
+  while read line; do
+    if [ -n "$line" ]; then
+      bing_cookies="$bing_cookies'${line}' "
+    fi
+  done < <(grep . /credentials/.cookies)
+  bing_cookies="${bing_cookies% }"
+fi
+
+# Exec main process
+python_cmd="python3 tg.py '$tg_token' $bing_cookies"
+eval $python_cmd


### PR DESCRIPTION
Fix #18 

The entrypoint script allows easily passing the `tg_token` and `bing_cookie` values from docker run to the python script, avoiding the need to specify the full python command with args in docker run each time.

Now the docker run command can just set the necessary environment variables or mounted files, and the entrypoint will handle running the python script with those values as arguments.

This simplifies invoking the application through docker by centralizing the argument handling in one place.