### PR TITLE
docs: add Deploy to Zeabur button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ If you want to use multiple cookies, you just need to set the key of secrets to 
 
 `flyctl secrets set bing_cookie_0=`_your bing_cookie_0_  
 
+### Method 5 (Deploy to Zeabur)
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/W66UCB?utm_source=tg_bing_dalle)
+
 ## Advanced
 
 ### GPT Enhance


### PR DESCRIPTION
Click on the button, and user will be redirected to the template page. Login to Zeabur and fill in the two variables, select a region, click deploy, the deployment will be finished in 1 minute.
<img width="1512" alt="image" src="https://github.com/yihong0618/tg_bing_dalle/assets/63531512/fa802dfc-cf6c-42fa-ac3a-8470b4730ce5">
<img width="1512" alt="project" src="https://github.com/yihong0618/tg_bing_dalle/assets/63531512/82589940-e362-4920-8dc1-c9361d083c50">
