### PR TITLE
feat: support to load gemini configuration from config.toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can also send your message like `/quota` or `quota?` or `@bot_name quota?` t
 note if you want to use prompt_gem you need:
 
 1. visit https://makersuite.google.com/app/apikey get the key
-2. export GOOGLE_GEMINI_KEY=${the_key}
+2. `export GOOGLE_GEMINI_KEY=${the_key}` or save in config.toml file
  
 
 ## How to
@@ -119,6 +119,10 @@ If you are running it using [Method 4 (Deploy to Fly.io)](#method-4-deploy-to-fl
 ```
 flyctl deploy -e config_file='config.toml'
 ```
+
+### Gemini Enhance
+
+To enable `prompt_gemini`, copy `config.sample.toml` to `config.toml`, and edit the file to setup your Gemini API.
 
 ### @bot
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -27,3 +27,7 @@
 # OpenAI model to use
 model = "gpt-4-1106-preview"
 
+#=====================================
+# Uncomment to enable prompt revise by Google Gemini
+# [google_gemini]
+# api_key = ""

--- a/tg.py
+++ b/tg.py
@@ -59,9 +59,12 @@ def main():
 
     # Setup Gemini
     use_gemini_client = False
+    gemini_conf: dict | None = config.get("google_gemini")
     GOOGLE_GEMINI_KEY = os.environ.get("GOOGLE_GEMINI_KEY")
-    if GOOGLE_GEMINI_KEY:
-        genai.configure(api_key=GOOGLE_GEMINI_KEY)
+    if not gemini_conf and GOOGLE_GEMINI_KEY:
+        gemini_conf = {"api_key": GOOGLE_GEMINI_KEY}
+    if gemini_conf is not None:
+        genai.configure(**gemini_conf)
         use_gemini_client = True
         print("Gemini init done.")
 
@@ -195,7 +198,10 @@ def main():
             s = pro_prompt_by_gemini(s, gemini_client)
             bot.reply_to(message, f"Rewrite by Gemini: {s}")
         except Exception as e:
-            bot.reply_to(message, "Something is wrong when GPT rewriting your prompt.")
+            bot.reply_to(
+                message,
+                "Something is wrong when Gemini rewriting your prompt.",
+            )
             print(str(e))
         print(f"{message.from_user.id} send prompt: {s}")
         respond_prompt(bot, message, bing_cookie_pool, bing_cookie_cnt, s)


### PR DESCRIPTION
Check the `google_gemini` section in config.toml at first. Otherwise fallback to the envvar.